### PR TITLE
Inject client Gson instance

### DIFF
--- a/src/main/java/com/galzzz/GoogleSheetsDropsExporter.java
+++ b/src/main/java/com/galzzz/GoogleSheetsDropsExporter.java
@@ -56,7 +56,8 @@ public class GoogleSheetsDropsExporter extends Plugin
 
     private static final MediaType JSON_MEDIA_TYPE = Objects.requireNonNull(MediaType.parse("application/json; charset=utf-8"));
 
-    private final Gson gson = new Gson();
+    @Inject
+    private Gson gson;
 
     private volatile List<String> filteredItems = Collections.emptyList();
     private volatile Set<String> filteredItemsLowercase = Collections.emptySet();


### PR DESCRIPTION
## Summary
- inject the RuneLite-provided Gson instance instead of creating a new one

## Testing
- ./gradlew build (fails: Unable to download https://repo.runelite.net/net/runelite/jshell/maven-metadata.xml - HTTP 403)


------
https://chatgpt.com/codex/tasks/task_e_68d9cfbb6c84832584bbdbff60edce5e